### PR TITLE
Fix code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "bcrypt": "^5.1.1",
     "express": "^4.17.1",
-    "express-session": "^1.18.1"
+    "express-session": "^1.18.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/server.js
+++ b/server.js
@@ -8,10 +8,17 @@ const session = require('express-session');
 const bcrypt = require('bcrypt');
 const path = require('path');
 const fs = require('fs').promises;
+const RateLimit = require('express-rate-limit');
 const accessLogsFile = path.join(__dirname, 'access_logs.json');
 const app = express();
 const port = 3000;
 const lastAccessTimes = {};
+
+// Rate limiter setup: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+});
 
 // Middleware setup
 app.use(express.json());
@@ -628,7 +635,7 @@ app.get('/login.html', (req, res) => {
 });
 
 // Route to serve the index page
-app.get('/index.html', requireAuth, (req, res) => {
+app.get('/index.html', requireAuth, limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/7](https://github.com/Willebrew/ResiLIVE/security/code-scanning/7)

To fix the problem, we will use the `express-rate-limit` package to add rate limiting to the Express application. This will involve:
1. Installing the `express-rate-limit` package.
2. Setting up a rate limiter with appropriate configuration.
3. Applying the rate limiter to the specific route handler that performs the file system access.