### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -625,7 +625,7 @@ app.get('/api', (req, res) => {
 });
 
 // Route to serve the login page
-app.get('/', (req, res) => {
+app.get('/', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'login.html'));
 });
 


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/5](https://github.com/Willebrew/ResiLIVE/security/code-scanning/5)

To fix the problem, we need to apply the existing rate limiter middleware to the route that serves the login page (`/`). This will ensure that the number of requests to this route is limited, preventing potential DoS attacks.

- Add the `limiter` middleware to the route handler for the login page (`/`).
- Ensure that the rate limiter is applied consistently across all routes that perform expensive operations.