### PR TITLE
Fix code scanning alert no. 1: Clear text transmission of sensitive cookie

### DIFF
--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ app.use(session({
     secret: 'your-secret-key',
     resave: false,
     saveUninitialized: true,
-    cookie: { secure: false }
+    cookie: { secure: true, httpOnly: true }
 }));
 
 // Route to serve the main API data file


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/1](https://github.com/Willebrew/ResiLIVE/security/code-scanning/1)

To fix the problem, we need to ensure that the session cookie is only transmitted over HTTPS connections. This can be achieved by setting the `secure` attribute to `true` in the session cookie configuration. Additionally, we should set the `httpOnly` attribute to prevent client-side scripts from accessing the cookie, further enhancing security.

- Update the session middleware configuration in `server.js` to set the `secure` and `httpOnly` attributes for the session cookie.
- Ensure that the application is running in an environment where HTTPS is enforced.