### PR TITLE
Fix code scanning alert no. 8: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "bcrypt": "^5.1.1",
     "express": "^4.17.1",
     "express-session": "^1.18.1",
-    "express-rate-limit": "^7.4.1"
+    "express-rate-limit": "^7.4.1",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const bcrypt = require('bcrypt');
 const path = require('path');
 const fs = require('fs').promises;
 const RateLimit = require('express-rate-limit');
+const lusca = require('lusca');
 const accessLogsFile = path.join(__dirname, 'access_logs.json');
 const app = express();
 const port = 3000;
@@ -29,6 +30,7 @@ app.use(session({
     saveUninitialized: true,
     cookie: { secure: true, httpOnly: true }
 }));
+app.use(lusca.csrf());
 
 // Route to serve the main API data file
 app.get('/api', (req, res) => {


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/8](https://github.com/Willebrew/ResiLIVE/security/code-scanning/8)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` library is a well-known middleware for this purpose. We will:
1. Install the `lusca` package.
2. Import the `lusca` package in the `server.js` file.
3. Add the CSRF middleware to the Express application.