### PR TITLE
Fix code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -622,7 +622,7 @@ async function removeExpiredCodes() {
 setInterval(removeExpiredCodes, 60000);
 
 // Route to serve the main API data file
-app.get('/api', (req, res) => {
+app.get('/api', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'data.json'));
 });
 


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/4](https://github.com/Willebrew/ResiLIVE/security/code-scanning/4)

To fix the problem, we need to apply rate limiting to the `/api` route. This can be done by using the existing `limiter` middleware that is already defined and used for other routes. We will add the `limiter` middleware to the `/api` route to ensure that it is protected against excessive requests.