### PR TITLE
Fix code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,7 @@ app.use(session({
 app.use(lusca.csrf());
 
 // Route to serve the main API data file
-app.get('/api', (req, res) => {
+app.get('/api', limiter, (req, res) => {
     res.sendFile(path.join(__dirname, 'data.json'));
 });
 


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/3](https://github.com/Willebrew/ResiLIVE/security/code-scanning/3)

To fix the problem, we need to apply the existing rate limiter to the specific route that performs the file system access. This will ensure that the number of requests to this endpoint is limited, preventing potential abuse and denial-of-service attacks.

- We will apply the `limiter` middleware to the `/api` route.
- This involves modifying the route definition to include the `limiter` middleware before the route handler.