### PR TITLE
Fix code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -821,7 +821,7 @@ app.get('/login.html', limiter, (req, res) => {
 });
 
 // Route to serve the index page
-app.get('/index.html', (req, res) => {
+app.get('/index.html', limiter, (req, res) => {
     if (!req.session.userId) {
         return res.redirect('/login.html');
     }


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/10](https://github.com/Willebrew/ResiLIVE/security/code-scanning/10)

To fix the problem, we need to apply rate limiting to the `/index.html` route. This can be done by using the `express-rate-limit` middleware, which is already imported and used in other routes in the same file. We will add the `limiter` middleware to the `/index.html` route to ensure it is protected against abuse.