### PR TITLE
Fix code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -808,7 +808,7 @@ app.get('/api', limiter, (req, res) => {
 });
 
 // Route to serve the login page
-app.get('/', (req, res) => {
+app.get('/', limiter, (req, res) => {
     if (!req.session.userId) {
         return res.redirect('/login.html');
     }


### PR DESCRIPTION
Fixes [https://github.com/Willebrew/ResiLIVE/security/code-scanning/9](https://github.com/Willebrew/ResiLIVE/security/code-scanning/9)

To fix the problem, we need to apply a rate limiter to the route handler on line 811 that serves the login page. This can be done using the `express-rate-limit` package, which is already imported and used in other parts of the code. We will create a rate limiter instance and apply it to the route handler.

1. Define a rate limiter instance with appropriate settings (e.g., maximum of 100 requests per 15 minutes).
2. Apply this rate limiter to the route handler on line 811.