### PR TITLE
Fix: Resolve CSP errors and repair Flatpickr integration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
         <button id="addAddressBtn" class="add-btn">+</button>
 
         <!-- Address details container (shown/hidden in app.js) -->
-        <div id="addressDetails" style="display: none;"></div>
+        <div id="addressDetails"></div>
     </main>
 </div>
 
@@ -125,7 +125,7 @@
             <label for="codeExpiryInput">Expires At:</label>
             <input type="text" id="codeExpiryInput" placeholder="Select date and time">
         </div>
-        <div class="popup-buttons" style="margin-top: 15px;">
+        <div class="popup-buttons">
             <button id="saveCodeBtn" class="action-btn">Save Code</button>
             <button id="cancelAddCodeBtn" class="close-btn-popup">Cancel</button>
         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -683,3 +683,11 @@ h3 {
     text-align: center;
     margin-bottom: 10px;
 }
+
+#addressDetails {
+    display: none;
+}
+
+.popup-buttons {
+    margin-top: 15px;
+}

--- a/server.js
+++ b/server.js
@@ -111,8 +111,8 @@ app.use((req, res, next) => {
 
     const cspDirectives = [
         "default-src 'self'",
-        `script-src 'self' 'nonce-${nonce}'`, // Allow self and scripts with the correct nonce
-        `style-src 'self' 'nonce-${nonce}'`,  // Allow self and styles with the correct nonce
+        `script-src-elem 'self' https://cdn.jsdelivr.net 'nonce-${nonce}'`, // Allow self and scripts with the correct nonce
+        `style-src-elem 'self' https://cdn.jsdelivr.net 'nonce-${nonce}'`,  // Allow self and styles with the correct nonce
         "img-src 'self' data:",              // Allow images from self and data URIs
         "font-src 'self' https://www.perplexity.ai data:", // Allow fonts from self, perplexity.ai, and data URIs
         "object-src 'none'",                 // Disallow plugins (Flash, etc.)


### PR DESCRIPTION
This commit addresses Content Security Policy (CSP) violations that prevented Flatpickr from loading and blocked inline styles.

Changes include:
- Modified `server.js` to update the CSP:
    - Added `https://cdn.jsdelivr.net` to `script-src-elem` and `style-src-elem` directives to allow loading Flatpickr assets.
    - Replaced `script-src` and `style-src` with the more specific `script-src-elem` and `style-src-elem` directives.
- Removed inline styles from `public/index.html`:
    - Removed `style="display: none;"` from `<div id="addressDetails">`.
    - Removed `style="margin-top: 15px;"` from `<div class="popup-buttons">`.
- Updated `public/style.css`:
    - Added `#addressDetails { display: none; }`.
    - Added `.popup-buttons { margin-top: 15px; }`.

These changes ensure that Flatpickr loads and functions correctly for date selection in the "Add Code" modal, and that previously inline styles are now handled via the external stylesheet, complying with the CSP.