### PR TITLE
Fix: Update CSP to allow specific inline style via hash

### DIFF
--- a/server.js
+++ b/server.js
@@ -120,6 +120,7 @@ app.use((req, res, next) => {
     const cspDirectives = [
         "default-src 'self'",
         `script-src-elem 'self' https://cdn.jsdelivr.net 'nonce-${nonce}'`, // Allow self and scripts with the correct nonce
+        "style-src 'self' https://cdn.jsdelivr.net 'sha256-lOLzuHiC/tzyOWpOjSY2MqilBHMQkoUoON+GTXvMbi0='",
         `style-src-elem 'self' https://cdn.jsdelivr.net 'nonce-${nonce}'`,  // Allow self and styles with the correct nonce
         "img-src 'self' data:",              // Allow images from self and data URIs
         "font-src 'self' https://www.perplexity.ai data:", // Allow fonts from self, perplexity.ai, and data URIs


### PR DESCRIPTION
Updated the Content Security Policy in server.js to include a specific hash for the `style-src` directive. This resolves an error where an inline style was being blocked due to CSP restrictions.

The hash 'sha256-lOLzuHiC/tzyOWpOjSY2MqilBHMQkoUoON+GTXvMbi0=' has been added to `style-src`, allowing the specific inline style to be applied without resorting to 'unsafe-inline'.