### PR TITLE
Fix: Correctly color UI logs based on content

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -873,9 +873,9 @@ function displayLogs(logs) {
         const timestamp = new Date(log.timestamp).toLocaleString();
 
         // If the log action contains "Access denied", style it in red; otherwise use the default.
-        const actionStyle = log.action.includes("Access denied")
-            ? 'color: #FF3B30;'
-            : 'color: var(--color-btn-add-bg);';
+        const actionStyle = log.action.toLowerCase().includes("denied")
+            ? 'color: #FF3B30;' // Red
+            : 'color: #32D74B;'; // Explicit green
 
         logEntry.innerHTML = `
             <span class="timestamp">${timestamp}</span><br>


### PR DESCRIPTION
Ensures that UI log messages containing the word "denied" (case-insensitive) are displayed in red, while all other log messages are displayed in green.

The `displayLogs` function in `public/app.js` was modified to:
- Use `log.action.toLowerCase().includes("denied")` for a case-insensitive check.
- Explicitly set the non-denied log color to `#32D74B` (green) to avoid potential issues with CSS variable resolution that might have caused previous incorrect coloring.