### PR TITLE
Fix: Ensure correct log entry colors in popup

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -721,10 +721,6 @@ h3 {
     color: var(--color-text);
 }
 
-.log-entry .action {
-    color: var(--color-btn-add-bg);
-}
-
 /********************************************************
   USER MANAGEMENT POPUP
 *********************************************************/


### PR DESCRIPTION
Removes a conflicting CSS rule for `.log-entry .action` that was setting a default green color. This rule could potentially interfere with or override the inline styles applied by JavaScript which are responsible for setting specific colors (red for denied, green for allowed) for log actions.

The `displayLogs` function in `public/app.js` already correctly assigns 'color: #FF3B30;' (red) for denied actions and 'color: #32D74B;' (green) for other actions via inline styles. By removing the general CSS color rule, we ensure that the JavaScript-applied styles are the sole source of truth for these colors, preventing the bug where all log entries might turn green after a while.

Manual testing should verify that denied logs remain red and other logs remain green over an extended period of observation in the logs popup.