### PR TITLE
Fix: Implement class-based styling for log entry colors

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -855,16 +855,20 @@ function displayLogs(logs) {
         const logEntry = document.createElement('div');
         logEntry.className = 'log-entry';
         const timestamp = new Date(log.timestamp).toLocaleString();
+        
+        let actionClass = 'action-allowed'; // Default to allowed (green)
+        // Ensure log.action exists and is a string before calling toLowerCase()
+        if (log.action && typeof log.action === 'string' && log.action.toLowerCase().includes("denied")) {
+            actionClass = 'action-denied'; // Set to denied (red) if applicable
+        }
 
-        // If the log action contains "Access denied", style it in red; otherwise use the default.
-        const actionStyle = log.action.toLowerCase().includes("denied")
-            ? 'color: #FF3B30;' // Red
-            : 'color: #32D74B;'; // Explicit green
+        // Ensure log.action is a string for safe display in innerHTML; display number as is.
+        const actionText = (typeof log.action === 'string' || typeof log.action === 'number') ? log.action : '(empty action)';
 
         logEntry.innerHTML = `
             <span class="timestamp">${timestamp}</span><br>
             <span class="player">${log.player}</span>: 
-            <span class="action" style="${actionStyle}">${log.action}</span>
+            <span class="action ${actionClass}">${actionText}</span>
         `;
         logContent.appendChild(logEntry);
     });

--- a/public/style.css
+++ b/public/style.css
@@ -722,7 +722,15 @@ h3 {
 }
 
 .log-entry .action {
-    color: var(--color-btn-add-bg);
+    color: var(--color-btn-add-bg); /* This is #32D74B, green */
+}
+
+.log-entry .action.action-denied {
+    color: #FF3B30; /* Red */
+}
+
+.log-entry .action.action-allowed {
+    color: #32D74B; /* Green */
 }
 
 /********************************************************


### PR DESCRIPTION
This commit addresses issues with log entry coloring in the logs popup:
1. The original problem where all logs might turn green over time.
2. A subsequent issue (after a previous fix attempt) where some log action text could appear white.

The solution involves:
- Modifying `public/style.css`:
    - Ensuring `.log-entry .action` has a default color of green.
    - Adding new CSS classes `.log-entry .action.action-denied` (for red text) and `.log-entry .action.action-allowed` (for green text).
- Modifying `public/app.js` (`displayLogs` function):
    - Instead of applying inline styles, the JavaScript now adds either the `action-denied` or `action-allowed` class to the log action's span.
    - Includes a check for `log.action` to ensure it's a string, displaying `(empty action)` and defaulting to green if `log.action` is null, undefined, or not a string. This prevents errors and ensures consistent styling.

This class-based approach provides a more robust and maintainable way to handle log colors, ensuring that styles are applied correctly and are less prone to unexpected overrides or unstyled states.