### PR TITLE
Improve UI and allowed users list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -416,10 +416,6 @@ function setupUIEventListeners() {
         updateAllowedUsersBtn.addEventListener('click', updateAllowedUsers);
     }
 
-    const removeSelectedUsersBtn = document.getElementById('removeSelectedUsersBtn');
-    if (removeSelectedUsersBtn) {
-        removeSelectedUsersBtn.addEventListener('click', removeSelectedUsers);
-    }
 
     // Event listener for "Save Code" button in the Add Code Modal
     const saveCodeBtn = document.getElementById('saveCodeBtn');
@@ -1575,15 +1571,22 @@ async function updateAllowedUsers() {
  * Renders the list of allowed users for the selected community.
  */
 function renderAllowedUsers() {
-    const allowedUsersDropdown = document.getElementById('allowedUsersDropdown');
-    if (!allowedUsersDropdown) return;
-    allowedUsersDropdown.innerHTML = '';
+    const allowedUsersList = document.getElementById('allowedUsersList');
+    if (!allowedUsersList) return;
+    allowedUsersList.innerHTML = '';
     if (selectedCommunity && selectedCommunity.allowedUsers) {
         selectedCommunity.allowedUsers.forEach(user => {
-            const option = document.createElement('option');
-            option.value = user;
-            option.textContent = user;
-            allowedUsersDropdown.appendChild(option);
+            const li = document.createElement('li');
+            li.className = 'allowed-user-item';
+            const span = document.createElement('span');
+            span.textContent = user;
+            const removeBtn = document.createElement('button');
+            removeBtn.textContent = '✖';
+            removeBtn.className = 'remove-btn-user';
+            removeBtn.addEventListener('click', () => removeAllowedUser(user));
+            li.appendChild(span);
+            li.appendChild(removeBtn);
+            allowedUsersList.appendChild(li);
         });
     }
     const allowedUsersManagement = document.getElementById('allowedUsersManagement');
@@ -1597,14 +1600,11 @@ function renderAllowedUsers() {
 }
 
 /**
- * Removes the selected users from the allowed users list and updates the server.
+ * Removes a specific user from the allowed users list and updates the server.
+ * @param {string} user - Username to remove
  */
-function removeSelectedUsers() {
-    const allowedUsersDropdown = document.getElementById('allowedUsersDropdown');
-    if (!allowedUsersDropdown) return;
-    Array.from(allowedUsersDropdown.selectedOptions).forEach(option => {
-        selectedCommunity.allowedUsers = selectedCommunity.allowedUsers.filter(u => u !== option.value);
-    });
+function removeAllowedUser(user) {
+    selectedCommunity.allowedUsers = selectedCommunity.allowedUsers.filter(u => u !== user);
     updateAllowedUsers();
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -81,11 +81,10 @@
             <!-- Allowed Users management block (admin only) -->
             <div id="allowedUsersManagement">
                 <h3>Allowed Users</h3>
-                <select id="allowedUsersDropdown" multiple></select>
-                <input type="text" id="allowedUsersInput" placeholder="Add usernames here">
-                <div class="button-group">
+                <ul id="allowedUsersList" class="allowed-users-list"></ul>
+                <div class="add-user-row">
+                    <input type="text" id="allowedUsersInput" placeholder="Add username">
                     <button id="updateAllowedUsersBtn" class="add-btn">Add</button>
-                    <button id="removeSelectedUsersBtn" class="remove-btn-user">Remove</button>
                 </div>
             </div>
         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -248,6 +248,7 @@ h1, h2, h3, h4, p {
         height: calc(100% - var(--topbar-height));
         z-index: 1000;
         transform: translateX(-100%);
+        width: 70vw;
     }
     .sidebar.sidebar-open {
         transform: translateX(0);
@@ -387,32 +388,59 @@ h1, h2, h3, h4, p {
     font-size: 1em;
 }
 
-#allowedUsersDropdown {
-    width: 100%;
-    min-height: 60px;
-    border: 1px solid var(--color-border);
+#allowedUsersList {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 10px 0;
+    max-height: 150px;
+    overflow-y: auto;
+}
+
+.allowed-user-item {
     background-color: #111111;
+    border: 1px solid var(--color-border);
     border-radius: var(--radius);
-    color: var(--color-text);
-    padding: 6px;
-    margin-bottom: 10px;
-    font-size: 0.9em;
+    margin-bottom: 5px;
+    padding: 5px 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    animation: fadeSlideIn 0.3s ease;
+}
+
+.allowed-user-item button {
+    background-color: var(--color-btn-remove-bg);
+    color: var(--color-btn-remove-text);
+    border: none;
+    border-radius: var(--btn-radius);
+    padding: 4px 8px;
+    font-size: 0.8em;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.allowed-user-item button:hover {
+    opacity: 0.8;
+}
+
+.add-user-row {
+    display: flex;
+    gap: 6px;
 }
 
 #allowedUsersInput {
-    width: 100%;
+    flex-grow: 1;
     border: 1px solid var(--color-border);
     background-color: #111111;
     border-radius: var(--radius);
     color: var(--color-text);
     padding: 6px;
-    margin-bottom: 10px;
     font-size: 0.9em;
 }
 
-.button-group {
-    display: flex;
-    justify-content: space-between;
+@keyframes fadeSlideIn {
+    from { opacity: 0; transform: translateY(-5px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 /********************************************************


### PR DESCRIPTION
## Summary
- redesign allowed users UI for consistency on mobile and desktop
- add fade-in animation for user list items
- tweak sidebar width for mobile

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6840981678ac8323a8d982d5cde945a5